### PR TITLE
Fix: trim ignores trailing newline

### DIFF
--- a/src/mb_trim.php
+++ b/src/mb_trim.php
@@ -12,7 +12,7 @@
 function mb_trim(string $string, string $characters = " \f\n\r\t\v\x00\u{00A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{2028}\u{2029}\u{202F}\u{205F}\u{3000}\u{0085}\u{180E}", ?string $encoding = null): string {
     // On supported versions, use a pre-calculated regex for performance.
     if (PHP_VERSION_ID >= 80200 && ($encoding === null || $encoding === "UTF-8") && $characters === " \f\n\r\t\v\x00\u{00A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{2028}\u{2029}\u{202F}\u{205F}\u{3000}\u{0085}\u{180E}") {
-        return preg_replace("/^[\s\0]+|[\s\0]+$/u", '', $string);
+        return preg_replace("/^[\s\0]+|[\s\0]+$/uD", '', $string);
     }
 
     try {
@@ -32,7 +32,7 @@ function mb_trim(string $string, string $characters = " \f\n\r\t\v\x00\u{00A0}\u
 
     $charMap = array_map(static fn(string $char): string => preg_quote($char, '/'), mb_str_split($characters));
     $regexClass = implode('', $charMap);
-    $regex = "/^[" . $regexClass . "]+|[" . $regexClass . "]+$/u";
+    $regex = "/^[" . $regexClass . "]+|[" . $regexClass . "]+$/uD";
 
     $return = preg_replace($regex, '', $string);
 
@@ -98,7 +98,7 @@ function mb_ltrim(string $string, string $characters = " \f\n\r\t\v\x00\u{00A0}\
 function mb_rtrim(string $string, string $characters = " \f\n\r\t\v\x00\u{00A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{2028}\u{2029}\u{202F}\u{205F}\u{3000}\u{0085}\u{180E}", ?string $encoding = null): string {
     // On supported versions, use a pre-calculated regex for performance.
     if (PHP_VERSION_ID >= 80200 && ($encoding === null || $encoding === "UTF-8") && $characters === " \f\n\r\t\v\x00\u{00A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{2028}\u{2029}\u{202F}\u{205F}\u{3000}\u{0085}\u{180E}") {
-        return preg_replace("/[\s\0]+$/u", '', $string);
+        return preg_replace("/[\s\0]+$/uD", '', $string);
     }
 
     try {
@@ -118,7 +118,7 @@ function mb_rtrim(string $string, string $characters = " \f\n\r\t\v\x00\u{00A0}\
 
     $charMap = array_map(static fn(string $char): string => preg_quote($char, '/'), mb_str_split($characters));
     $regexClass = implode('', $charMap);
-    $regex = "/[" . $regexClass . "]+$/u";
+    $regex = "/[" . $regexClass . "]+$/uD";
 
     $return = preg_replace($regex, '', $string);
 
@@ -128,4 +128,3 @@ function mb_rtrim(string $string, string $characters = " \f\n\r\t\v\x00\u{00A0}\
 
     return $return;
 }
-

--- a/tests/MbTrimTest.php
+++ b/tests/MbTrimTest.php
@@ -68,6 +68,8 @@ class MbTrimTest extends TestCase {
 
         $this->assertSame("f", mb_trim("foo", "oo"));
 
+        $this->assertSame("foo\n", mb_trim("foo\n", "o"));
+        $this->assertSame("foo\n", mb_rtrim("foo\n", "o"));
 
         $this->expectException(\ValueError::class);
         mb_trim( "\u{180F}", "", "NULL");


### PR DESCRIPTION
By default the `$` in a regex pattern will also match any character _immediately prior to the final newline_.

The result is that `mb_trim("foo\n", "o")` will give `f\n` instead of the expected `foo\n`.

This PR adds the `D` pcre modifier to disable this behaviour, and adds an appropriate test case.

See https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php for a full description of the `D` modifier.